### PR TITLE
Added number of tokens validation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -28,22 +28,24 @@ exports.parseCommand = parseCommand;
 const parseInputTokens = (command, inputTokens) => {
   for (let i = 0; i < command.patterns.length; i++) { // for each pattern
     const patternTokens = command.patterns[i].tokens;
-    const args = {};
-    let match = true;
-    for (let j = 0; j < patternTokens.length; j++) { // for each token in pattern
-      const patternToken = patternTokens[j];
-      if (patternToken.isArg) {
-        args[patternToken.value] = inputTokens[j];
-      }
-      else {
-        if (inputTokens[j] !== patternToken.value) {
-          match = false;
-          break;
+    if (patternTokens.length === inputTokens.length) {
+      const args = {};
+      let match = true;
+      for (let j = 0; j < patternTokens.length; j++) { // for each token in pattern
+        const patternToken = patternTokens[j];
+        if (patternToken.isArg) {
+          args[patternToken.value] = inputTokens[j];
+        }
+        else {
+          if (inputTokens[j] !== patternToken.value) {
+            match = false;
+            break;
+          }
         }
       }
+      if (match)
+        return { args };
     }
-    if (match)
-      return { args };
   }
   return null;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,9 +58,17 @@ describe("static phrase command", () => {
     }
   });
 
+  jarvis.addCommand({
+    command: "how are you doing",
+    handler: ({ line, args }) => {
+      return "I'm doing well";
+    }
+  });
+
   test("should match the phrase exactly", async () => {
     expect(await jarvis.send("how are you")).toEqual("I'm fine");
     expect(await jarvis.send("how are")).toEqual(null);
+    expect(await jarvis.send("how are you doing")).toEqual("I'm doing well");
   });
 });
 


### PR DESCRIPTION
This is to avoid the miss match among different commands with same start.

Ex:
```
  jarvis.addCommand({
    command: "how are you",
    handler: ({ line, args }) => {
      return "I'm fine";
    }
  });

  jarvis.addCommand({
    command: "how are you doing",
    handler: ({ line, args }) => {
      return "I'm doing well";
    }
  });

  test("should match the phrase exactly", async () => {
    expect(await jarvis.send("how are you")).toEqual("I'm fine");
    expect(await jarvis.send("how are you doing")).toEqual("I'm doing well");
  });
```