### PR TITLE
Added macro functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,17 @@
-const { 
-  parseCommand, 
-  tokenize, 
-  parseInputTokens 
+const {
+  parseCommand,
+  tokenize,
+  parseInputTokens,
+  parseMacroInputTokens,
+  parseMacroSubCommand
 } = require("./src/utils");
 
 class Jarvis {
   constructor() {
     this.commands = []; // list of registered commands
+    this.macros = [];
     this.activeCommand = null; // currently active command
+    this.activeMacro = null;
     this.state = {}; // state variables for currently active command
   }
 
@@ -15,17 +19,17 @@ class Jarvis {
    * Registers a new command with Jarvis
    * USAGE: jarvis.addCommand({ command: 'test', handler: () => {}});
    */
-  addCommand({command, handler, aliases}) {
+  addCommand({ command, handler, aliases }) {
     const patterns = [];
-    patterns.push({tokens: parseCommand(command)});
+    patterns.push({ tokens: parseCommand(command) });
     if (aliases) {
       aliases.forEach((alias) => {
-        patterns.push({tokens: parseCommand(alias)})
+        patterns.push({ tokens: parseCommand(alias) })
       });
     }
 
     this.commands.push({
-      command: command, 
+      command: command,
       handler: handler,
       tokens: parseCommand(command),
       patterns
@@ -67,8 +71,10 @@ class Jarvis {
     return null;
   }
 
-  // if command is null, then consider as accepting prompted input
-  // for the active command
+  /**
+   * if command is null, then consider as accepting prompted input
+   * for the active command
+   */
   async _runCommand(command, line) {
     const inputTokens = tokenize(line);
     const handler = command ? command.handler : this.activeCommand.handler;
@@ -94,8 +100,79 @@ class Jarvis {
       return this._runCommand(null, line);
     }
 
+    if (/how to /i.test(line.trim())) {
+      this.activeMacro = {
+        command: line.replace('how to', '').trim(),
+        subCommands: []
+      }
+      const out = 'You are now entering a macro. Type the statements, one line at a time. When done, type \'end\'.'
+      return out;
+    }
+
+    if (this.activeMacro) {
+      if (line === 'end') {
+        this._addMacro(this.activeMacro);
+        const out = `Macro "${this.activeMacro.command}" has been added.`;
+        this.activeMacro = null;
+        return out;
+      }
+      this.activeMacro.subCommands.push(line);
+      return;
+    }
+
+    return await this._execute(line);
+  }
+
+  /**
+   * if the 'line' is not found in commands
+   * it will search in macros
+   */
+  async _execute(line) {
     const command = this._findCommand(line);
-    return command ? this._runCommand(command, line) : null;
+    if (command) {
+      return this._runCommand(command, line);
+    } else {
+      const macro = this._findMacro(line);
+      return macro ? await this._runMacro(macro) : null;
+    }
+  }
+
+  /**
+   * Register a new macro with JARVIS
+   * USAGE: jarvis._addMacro(macro);
+   */
+  _addMacro({ command, subCommands }) {
+    this.macros.push({
+      command: command,
+      tokens: parseCommand(command),
+      subCommands: subCommands,
+    })
+  }
+
+  /**
+   * Execute sub commands of the macro
+   */
+  async _runMacro(macro) {
+    let subCommandsStatus = [];
+    for (let line of macro.subCommands) {
+      line = parseMacroSubCommand(line, macro.args);
+      subCommandsStatus.push(await this._execute(line));
+    }
+    return subCommandsStatus;
+  }
+
+  /**
+   * Find the macro by sending macro name
+   */
+  _findMacro(line) {
+    const inputTokens = tokenize(line);
+    for (let i = 0; i < this.macros.length; i++) {
+      const macroCommand = this.macros[i];
+      const args = parseMacroInputTokens(macroCommand, inputTokens);
+      if (args)
+        return Object.assign({}, this.macros[i], args)
+    }
+    return null;
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,7 @@ const tokenize = (line) => {
 };
 exports.tokenize = tokenize;
 
-// converts 'hello <name>' to 
+// converts 'hello $name' to 
 // [{value: 'hello', isArg: false}, {value: name, isArg: true}]
 const parseCommand = (commandStr) => {
   const tokens = [];
@@ -49,3 +49,46 @@ const parseInputTokens = (command, inputTokens) => {
 };
 
 exports.parseInputTokens = parseInputTokens;
+
+// checks tokens against the macro command
+// returns args if match, else null
+const parseMacroInputTokens = (command, inputTokens) => {
+  const patternTokens = command.tokens;
+  if (patternTokens.length === inputTokens.length) {
+    const args = {};
+    let match = true;
+    for (let j = 0; j < patternTokens.length; j++) { // for each token in pattern
+      const patternToken = patternTokens[j];
+      if (patternToken.isArg) {
+        args[patternToken.value] = inputTokens[j];
+      }
+      else {
+        if (inputTokens[j] !== patternToken.value) {
+          match = false;
+          break;
+        }
+      }
+    }
+    if (match)
+      return { args };
+  }
+  return null;
+};
+exports.parseMacroInputTokens = parseMacroInputTokens;
+
+// change variable tokens to values of args
+// returns same string if no variables found
+const parseMacroSubCommand = (line, args) => {
+  let tokens = parseCommand(line);
+  let parsedLine = line;
+  tokens.forEach((token) => {
+    if (token.isArg) {
+      if (args[token.value]) {
+        parsedLine = parsedLine.replace(`$${token.value}`, `"${args[token.value]}"`);
+      }
+    }
+  })
+
+  return parsedLine;
+};
+exports.parseMacroSubCommand = parseMacroSubCommand;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -119,4 +119,87 @@ describe("aliases", () => {
   });
 });
 
+describe('macros', () => {
+  const jarvis = new Jarvis();
 
+  jarvis.addCommand({
+    command: 'run hello',
+    handler: ({ args }) => {
+      return `Hello`;
+    }
+  });
+
+  jarvis.addCommand({
+    command: 'run world',
+    handler: ({ args }) => {
+      return `world`;
+    }
+  });
+
+  jarvis.addCommand({
+    command: 'load $language',
+    handler: ({ args }) => {
+      return `Running, ${args.language}`;
+    }
+  });
+
+  jarvis.addCommand({
+    command: 'say $string',
+    handler: ({ args }) => {
+      return `${args.string}`;
+    }
+  });
+
+  test('initialize a macro', async () => {
+    expect(await jarvis.send('how to programme'))
+      .toEqual('You are now entering a macro. Type the statements, one line at a time. When done, type \'end\'.');
+  });
+
+  test('add macro with no variables', async () => {
+    await jarvis.send('how to write');
+    await jarvis.send('run hello');
+    await jarvis.send('run world');
+
+    expect(await jarvis.send('end'))
+      .toEqual('Macro "write" has been added.');
+  });
+
+  test('run a macro', async () => {
+    expect(await jarvis.send('write'))
+      .toEqual(['Hello', 'world']);
+  });
+
+  test('macro with no multiple variables', async () => {
+    await jarvis.send('how to code $language $message');
+    await jarvis.send('load $language');
+    await jarvis.send('say $message')
+    await jarvis.send('end');
+
+    expect(await jarvis.send('code JavaScript "Hello World"'))
+      .toEqual(['Running, JavaScript', 'Hello World']);
+  });
+
+  test('macro with undefined sub commands', async () => {
+    await jarvis.send('how to test $language');
+    await jarvis.send('try $language');
+    await jarvis.send('end');
+
+    expect(await jarvis.send('test JavaScript'))
+      .toEqual([null]);
+  });
+
+  test('macro with inner macro', async () => {
+    await jarvis.send('how to inner_macro $str1 $str2');
+    await jarvis.send('say $str1');
+    await jarvis.send('say $str2');
+    await jarvis.send('end');
+
+    await jarvis.send('how to outer_macro $string1 $string2 $string3');
+    await jarvis.send('say $string1');
+    await jarvis.send('inner_macro $string2 $string3');
+    await jarvis.send('end');
+
+    expect(await jarvis.send('outer_macro "Normal Command" "Inner Command 1" "Inner Command 2"'))
+      .toEqual(['Normal Command', ['Inner Command 1', 'Inner Command 2']]);
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,11 +1,13 @@
-const { 
-  parseCommand, 
-  tokenize, 
-  parseInputTokens 
+const {
+  parseCommand,
+  tokenize,
+  parseInputTokens,
+  parseMacroInputTokens,
+  parseMacroSubCommand
 } = require("../src/utils");
 
 describe('tokenize', () => {
-  
+
   test('double quoted strings', () => {
     expect(tokenize('hello world "Hello World"'))
       .toEqual(['hello', 'world', 'Hello World']);
@@ -25,22 +27,82 @@ describe('tokenize', () => {
 });
 
 describe('parseCommand', () => {
-  
+
   test('basic command', () => {
     expect(parseCommand('hello $name'))
       .toEqual([
-        {value: 'hello', isArg: false}, {value: 'name', isArg: true}
+        { value: 'hello', isArg: false }, { value: 'name', isArg: true }
       ]);
-  }); 
+  });
 
   test('basic command with infix', () => {
     expect(parseCommand('hello $name how are you'))
       .toEqual([
-        {value: 'hello', isArg: false}, 
-        {value: 'name', isArg: true},
-        {value: 'how', isArg: false}, 
-        {value: 'are', isArg: false}, 
-        {value: 'you', isArg: false}
+        { value: 'hello', isArg: false },
+        { value: 'name', isArg: true },
+        { value: 'how', isArg: false },
+        { value: 'are', isArg: false },
+        { value: 'you', isArg: false }
       ]);
-  }); 
+  });
+});
+
+describe('macros', () => {
+  test('macro input tokens validation with no variables', () => {
+    expect(parseMacroInputTokens(
+      {
+        tokens: [
+          { value: 'how', isArg: false },
+          { value: 'to', isArg: false },
+          { value: 'programme', isArg: false }
+        ]
+      },
+      ['how', 'to', 'programme']
+    ))
+      .toEqual({ args: {} });
+  });
+
+  test('macro input tokens mismatch', () => {
+    expect(parseMacroInputTokens(
+      {
+        tokens: [
+          { value: 'how', isArg: false },
+          { value: 'to', isArg: false },
+          { value: 'programme', isArg: false }
+        ]
+      },
+      ['how', 'to', 'login']
+    ))
+      .toEqual(null);
+  });
+
+  test('macro input tokens validation with variables', () => {
+    expect(parseMacroInputTokens(
+      {
+        tokens: [
+          { value: 'how', isArg: false },
+          { value: 'to', isArg: false },
+          { value: 'programme', isArg: false },
+          { value: 'language', isArg: true }
+        ]
+      },
+      ['how', 'to', 'programme', 'JavaScript']
+    ))
+      .toEqual({ args: { language: 'JavaScript' } });
+  });
+
+  test('macro sub command with no variables', () => {
+    expect(parseMacroSubCommand('run hello', {}))
+      .toEqual('run hello');
+  });
+
+  test('macro sub command with variables', () => {
+    expect(parseMacroSubCommand('run $code', { code: "Hello World" }))
+      .toEqual("run \"Hello World\"");
+  });
+
+  test('macro sub command with missing variable in args', () => {
+    expect(parseMacroSubCommand('run $code', {}))
+      .toEqual("run $code");
+  });
 });


### PR DESCRIPTION
### Macro

Example:

#### Basic Macro
```
  const jarvis = new Jarvis();

  jarvis.addCommand({
    command: 'load $language',
    handler: ({ args }) => {
      return `Running, ${args.language}`;
    }
  });

  jarvis.addCommand({
    command: 'say $string',
    handler: ({ args }) => {
      return `${args.string}`;
    }
  });

  test('macro with no multiple variables', async () => {
    await jarvis.send('how to code $language $message');
    await jarvis.send('load $language');
    await jarvis.send('say $message')
    await jarvis.send('end');

    expect(await jarvis.send('code JavaScript "Hello World"'))
      .toEqual(['Running, JavaScript', 'Hello World']);
  });
```

#### Inner Macro
```
  test('macro with inner macro', async () => {
    await jarvis.send('how to inner_macro $str1 $str2');
    await jarvis.send('say $str1');
    await jarvis.send('say $str2');
    await jarvis.send('end');

    await jarvis.send('how to outer_macro $string1 $string2 $string3');
    await jarvis.send('say $string1');
    await jarvis.send('inner_macro $string2 $string3');
    await jarvis.send('end');

    expect(await jarvis.send('outer_macro "Normal Command" "Inner Command 1" "Inner Command 2"'))
      .toEqual(['Normal Command', ['Inner Command 1', 'Inner Command 2']]);
  });
```