### PR TITLE
Adding history feature to Jarvis

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,19 @@ class Jarvis {
     this.commands = []; // list of registered commands
     this.activeCommand = null; // currently active command
     this.state = {}; // state variables for currently active command
+
+    this.commandHistory = [];
+  }
+
+  clearCommandHistory() { 
+    this.commandHistory = []; 
+  }
+  getCommandHistory() {
+    return this.commandHistory;
+  } 
+
+  updateCommandHistory(cmd){
+    this.commandHistory.push(cmd);
   }
 
   /**
@@ -85,6 +98,14 @@ class Jarvis {
    * Sends a command to the shell
    */
   async send(line) {
+
+    if(line === 'history'){
+      return this.getCommandHistory();
+    }
+    else{
+      this.updateCommandHistory(line);
+    }
+    
     if (this.activeCommand) {
       if (line === '..') {
         const out = 'Done with ' + this.activeCommand.command + '.';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,32 @@
 const Jarvis = require("../index");
 
+describe("test command history", async () => {
+  const jarvis = new Jarvis();
+
+  jarvis.addCommand({command: "command 1", handler: ({ context, line }) => { return "tested: " + line; }});
+  jarvis.addCommand({command: "command 2", handler: ({ context, line }) => { return "tested: " + line; }});
+  jarvis.addCommand({command: "command 3", handler: ({ context, line }) => { return "tested: " + line; }});
+
+  jarvis.send("command 1")
+  jarvis.send("command 2")
+  jarvis.send("command 3")
+
+  test("should return the expected output", async () => {
+    expect(await jarvis.send("history")).toEqual(['command 1','command 2','command 3']);
+  });
+});
+
+describe("test no history", async () => {
+  const jarvis = new Jarvis();
+  jarvis.clearCommandHistory();
+
+  test("should return null array", async () => {
+    expect(await jarvis.send("history")).toEqual([]);
+  });
+
+});
+
+
 describe("basic command", async () => {
   const jarvis = new Jarvis();
   jarvis.addCommand({


### PR DESCRIPTION
**Get the command History**
Example 1
```
const jarvis = new Jarvis();

  jarvis.addCommand({command: "command 1", handler: ({ context, line }) => { return "tested: " + line; }});
  jarvis.addCommand({command: "command 2", handler: ({ context, line }) => { return "tested: " + line; }});
  jarvis.addCommand({command: "command 3", handler: ({ context, line }) => { return "tested: " + line; }});

  jarvis.send("command 1")
  jarvis.send("command 2")
  jarvis.send("command 3")

  test("should return the expected output", async () => {
    expect(await jarvis.send("history")).toEqual(['command 1','command 2','command 3']);
  });

```
Example 2
```
const jarvis = new Jarvis();
  jarvis.clearCommandHistory();

  test("should return null array", async () => {
    expect(await jarvis.send("history")).toEqual([]);
  });

```