### PR TITLE
Add script mode to jarvis

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ const {
   parseInputTokens,
   parseMacroInputTokens,
   parseMacroSubCommand,
-  parseConstants
+  parseConstants,
+  parseScript,
+  validateScript
 } = require("./src/utils");
 
 class Jarvis {
@@ -16,6 +18,18 @@ class Jarvis {
     this.activeConstants = null; // currently active constants
     this.state = {}; // state variables for currently active command
     this.constants = {}; // registered constants
+  }
+
+  /**
+   * Checks for available scripts to switch mode to script mode if a
+   * script with specified extension is provided
+   * USAGE: jarvis.addScriptMode('jarvis', 'script.jarvis');
+   */
+  async addScriptMode(extension, script) {
+    if (script && validateScript(extension, script)) {
+      return await this._runScript(script);
+    }
+    return null;
   }
 
   /**
@@ -111,7 +125,7 @@ class Jarvis {
       return this._runCommand(null, line);
     }
 
-    if (line.startsWith("how to")) {
+    if (line.startsWith("how to ")) {
       let macroCommand = line.replace('how to', '').trim();
       if (this._findMacro(macroCommand)) {
         return `Macro name already exists!`
@@ -228,6 +242,18 @@ class Jarvis {
         return Object.assign({}, macro, args)
     }
     return null;
+  }
+
+  /**
+   * Execute a provided script
+   */
+  async _runScript(script) {
+    let res = [];
+    const commands = parseScript(script);
+    for (const command of commands) {
+      res.push(await this.send(command));
+    }
+    return res;
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,8 @@
 // jarvis, just another rudimentary verbal interface shell
 // converts 'hello "John Doe"' to ['hello', 'John, Doe']
-const tokenize = (line) => {
+const fs = require("fs");
+const path = require("path");
+const tokenize = line => {
   const tokens = line.match(/"([^"]+)"|\S+/g);
   for (let i = 0; i < tokens.length; i++) {
     tokens[i] = tokens[i].replace(/"/g, '');
@@ -109,3 +111,22 @@ const parseConstants = (line, constants) => {
   return parsedLine;
 }
 exports.parseConstants = parseConstants;
+
+// returns string content by reading a script
+const parseScript = filename => {
+  const content = fs.readFileSync(filename, "utf8");
+  const lines = content.split("\n");
+  const filteredCommands = lines.filter(line => {
+    return line !== "";
+  });
+  return filteredCommands;
+};
+exports.parseScript = parseScript;
+
+// checks the validity of a provided script
+const validateScript = (extension, file) => {
+  if (path.extname(file) === `.${extension}`) {
+    return true;
+  }
+};
+exports.validateScript = validateScript;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -262,3 +262,47 @@ describe("constants", async () => {
     expect(await jarvis.send('describe $NAME')).toEqual(['JARVIS', '1']);
   });
 });
+
+describe("scripts", () => {
+  const jarvis = new Jarvis();
+
+  jarvis.addCommand({
+    command: "run hello",
+    handler: ({ args }) => {
+      return `Hello`;
+    }
+  });
+
+  jarvis.addCommand({
+    command: "run world",
+    handler: ({ args }) => {
+      return `world`;
+    }
+  });
+
+  jarvis.addCommand({
+    command: "load $language",
+    handler: ({ args }) => {
+      return `Running, ${args.language}`;
+    }
+  });
+
+  jarvis.addCommand({
+    command: "say $string",
+    handler: ({ args }) => {
+      return `${args.string}`;
+    }
+  });
+
+  test("Run in script mode", async () => {
+    expect(await jarvis.addScriptMode("jarvis", `${__dirname}/resources/test.jarvis`)).toEqual(["Hello", "world", "Running, $language", "$string"]);
+  });
+
+  test("Script file not specified", async () => {
+    expect(await jarvis.addScriptMode("jarvis", null)).toEqual(null);
+  });
+
+  test("Invalid script extension", async () => {
+    expect(await jarvis.addScriptMode("jarvis",`${__dirname}/resources/test.invalid`)).toEqual(null);
+  });
+});

--- a/test/resources/test.jarvis
+++ b/test/resources/test.jarvis
@@ -1,0 +1,4 @@
+run hello
+run world
+load $language
+say $string


### PR DESCRIPTION
This feature provides capability run a script  with a pre-specified extension,

- An example command is as follows,
```
$ kasaya sampleScript.kasaya 
```
- A sample test case is as follows,
```
describe("scripts", () => {
  const jarvis = new Jarvis();

  jarvis.addCommand({
    command: "run hello",
    handler: ({ args }) => {
      return `Hello`;
    }
  });

  jarvis.addCommand({
    command: "run world",
    handler: ({ args }) => {
      return `world`;
    }
  });

  jarvis.addCommand({
    command: "load $language",
    handler: ({ args }) => {
      return `Running, ${args.language}`;
    }
  });

  jarvis.addCommand({
    command: "say $string",
    handler: ({ args }) => {
      return `${args.string}`;
    }
  });

  test("Run in script mode", async () => {
    process.argv[2] = `${__dirname}/resources/test.jarvis`;
    expect(await jarvis.addScriptMode("jarvis")).toEqual([
      "Hello",
      "world",
      "Running, $language",
      "$string"
    ]);
  });
}
```
 