### PR TITLE
Added script handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,9 @@ class Jarvis {
    * script with specified extension is provided
    * USAGE: jarvis.addScriptMode('jarvis', 'script.jarvis');
    */
-  async addScriptMode(extension, script) {
+  async addScriptMode(extension, script, handler = () => { }) {
     if (script && validateScript(extension, script)) {
-      return await this._runScript(script);
+      return await this._runScript(script, handler);
     }
     return null;
   }
@@ -247,10 +247,12 @@ class Jarvis {
   /**
    * Execute a provided script
    */
-  async _runScript(script) {
+  async _runScript(script, handler) {
     let res = [];
     const commands = parseScript(script);
-    for (const command of commands) {
+    const execResult = await handler({ script, commands });
+    const updatedCommands = execResult ? execResult : commands;
+    for (const command of updatedCommands) {
       res.push(await this.send(command));
     }
     return res;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -298,6 +298,13 @@ describe("scripts", () => {
     }
   });
 
+  jarvis.addCommand({
+    command: "run internal command",
+    handler: ({ args }) => {
+      return `Running, internal command`;
+    }
+  });
+
   test("Run in script mode", async () => {
     expect(await jarvis.addScriptMode("jarvis", `${__dirname}/resources/test.jarvis`)).toEqual(["Hello", "world", "Running, $language", "$string"]);
   });
@@ -308,5 +315,19 @@ describe("scripts", () => {
 
   test("Invalid script extension", async () => {
     expect(await jarvis.addScriptMode("jarvis", `${__dirname}/resources/test.invalid`)).toEqual(null);
+  });
+
+  test("Script handler should have script path and extracted commands", async () => {
+    await jarvis.addScriptMode("jarvis", `${__dirname}/resources/script-handler.jarvis`, ({ script, commands }) => {
+      expect(script).toEqual(`${__dirname}/resources/script-handler.jarvis`);
+      expect(commands).toEqual(['run hello', 'run world', 'load JARVIS']);
+    })
+  });
+
+  test("Script handler can run some internal commands", async () => {
+    expect(await jarvis.addScriptMode("jarvis", `${__dirname}/resources/script-handler.jarvis`, async ({ commands }) => {
+      commands.push('run internal command');
+      return commands;
+    })).toEqual['Hello', 'world', 'Running, JARVIS', 'Running, internal command'];
   });
 });

--- a/test/resources/script-handler.jarvis
+++ b/test/resources/script-handler.jarvis
@@ -1,0 +1,3 @@
+run hello
+run world
+load JARVIS


### PR DESCRIPTION
This allows JARVIS users to get the control over the script before it runs, so the users can make changes to input script at the runtime hiding the complexity from the script.

Example: 
```
// resources/script-handler.jarvis
  run hello
  run world
  load JARVIS

// jarvis-test.js
 const jarvis = new Jarvis();

 jarvis.addCommand({
    command: "run hello",
    handler: ({ args }) => {
      return `Hello`;
    }
  });

  jarvis.addCommand({
    command: "run world",
    handler: ({ args }) => {
      return `world`;
    }
  });

  jarvis.addCommand({
    command: "load $language",
    handler: ({ args }) => {
      return `Running, ${args.language}`;
    }
  });

  jarvis.addCommand({
    command: "run internal command",
    handler: ({ args }) => {
      return `Running, internal command`;
    }
  });

  test("Script handler can run some internal commands", async () => {
    expect(await jarvis.addScriptMode("jarvis", `${__dirname}/resources/script-handler.jarvis`, async ({ commands }) => {
      commands.push('run internal command');
      return commands;
    })).toEqual['Hello', 'world', 'Running, JARVIS', 'Running, internal command'];
  });
```