### PR TITLE
Added single line comment support for script mode

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -117,7 +117,7 @@ const parseScript = filename => {
   const content = fs.readFileSync(filename, "utf8");
   const lines = content.split("\n");
   const filteredCommands = lines.filter(line => {
-    return line !== "";
+    return line !== "" && !line.trim().startsWith("#");
   });
   return filteredCommands;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -299,7 +299,7 @@ describe("scripts", () => {
   });
 
   test("Run in script mode", async () => {
-    expect(await jarvis.addScriptMode("jarvis", `${__dirname}/resources/test.jarvis`)).toEqual(["Hello", "world", "Running, $language", "$string"]);
+    expect(await jarvis.addScriptMode("jarvis", `${__dirname}/resources/test.jarvis`)).toEqual(["Hello", "world", "Running, JavaScript", "Bye"]);
   });
 
   test("Script file not specified", async () => {

--- a/test/resources/test.jarvis
+++ b/test/resources/test.jarvis
@@ -1,4 +1,5 @@
 run hello
 run world
-load $language
-say $string
+# single line comment
+load JavaScript
+say Bye

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3,7 +3,8 @@ const {
   tokenize,
   parseInputTokens,
   parseMacroInputTokens,
-  parseMacroSubCommand
+  parseMacroSubCommand,
+  parseScript
 } = require("../src/utils");
 
 describe('tokenize', () => {
@@ -106,3 +107,10 @@ describe('macros', () => {
       .toEqual("run $code");
   });
 });
+
+describe("scripts", () => {
+  test("single line comments", () => {
+    expect(parseScript(`${__dirname}/resources/test.jarvis`))
+      .toEqual(["run hello", "run world", "load JavaScript", "say Bye"]);
+  });
+}); 


### PR DESCRIPTION
This allows single line comments within scripts, with the use of `#` at the beginning of a line.

Example:
```
// script.jarvis
    run hello
    run world
    # single line comment
    load JavaScript
    say Bye

// utils.test.js
    describe("scripts", () => {
      test("single line comments", () => {
        expect(parseScript(`${__dirname}/resources/script.jarvis`))
          .toEqual(["run hello", "run world", "load JavaScript", "say Bye"]);
      });
    });
```