### PR TITLE
Added use of execution blocks for script mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ class Jarvis {
     this.activeConstants = null; // currently active constants
     this.state = {}; // state variables for currently active command
     this.constants = {}; // registered constants
+    this.isExecutorActive = false; // state variable for executor status
   }
 
   /**
@@ -250,10 +251,28 @@ class Jarvis {
   async _runScript(script) {
     let res = [];
     const commands = parseScript(script);
-    for (const command of commands) {
-      res.push(await this.send(command));
+    if (Array.isArray(commands)) {
+      for (const command of commands) {
+        if (!this.activeConstants && !this.activeMacro) {
+          if (command.startsWith("start")) {
+            this.isExecutorActive = true;
+            continue;
+          }
+          else if (command === 'end') {
+            this.isExecutorActive = false;
+            continue;
+          }
+        }
+        if (this.isExecutorActive || this.activeMacro || this.activeConstants || command.startsWith('in this context')
+          || command.startsWith('how to')) {
+          res.push(await this.send(command));
+        }
+      }
+      return res;
     }
-    return res;
+    else {
+      return commands
+    }
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -114,10 +114,19 @@ exports.parseConstants = parseConstants;
 
 // returns string content by reading a script
 const parseScript = filename => {
-  const content = fs.readFileSync(filename, "utf8");
+  let content;
+  try {
+    content = fs.readFileSync(filename, "utf8");
+  } catch (error) {
+    return 'Could not read file from the specified location!';
+  }
   const lines = content.split("\n");
-  const filteredCommands = lines.filter(line => {
-    return line !== "" && !line.trim().startsWith("#");
+  const filteredCommands = [];
+  lines.forEach((line) => {
+    line = line.trim();
+    if (line !== "" && !line.startsWith("#")) {
+      filteredCommands.push(line);
+    }
   });
   return filteredCommands;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -302,11 +302,27 @@ describe("scripts", () => {
     expect(await jarvis.addScriptMode("jarvis", `${__dirname}/resources/test.jarvis`)).toEqual(["Hello", "world", "Running, JavaScript", "Bye"]);
   });
 
+  test("Run script with a single executor", async () => {
+    const scriptResponse = await jarvis.addScriptMode("jarvis", `${__dirname}/resources/executor.jarvis`);
+    expect(scriptResponse[scriptResponse.length - 2]).toEqual(["Hello", "world"]);
+    expect(scriptResponse[scriptResponse.length - 1]).toEqual(["Running, JavaScript", "Bye"]);
+  });
+
+  test("Run script with multiple executors", async () => {
+    const scriptResponse = await jarvis.addScriptMode("jarvis", `${__dirname}/resources/executors.jarvis`);
+    expect(scriptResponse[scriptResponse.length - 2]).toEqual(['Hello', 'world']);
+    expect(scriptResponse[scriptResponse.length - 1]).toEqual(['Running, JavaScript', 'Bye']);
+  });
+
   test("Script file not specified", async () => {
     expect(await jarvis.addScriptMode("jarvis", null)).toEqual(null);
   });
 
   test("Invalid script extension", async () => {
     expect(await jarvis.addScriptMode("jarvis", `${__dirname}/resources/test.invalid`)).toEqual(null);
+  });
+
+  test("Invalid script path", async () => {
+    expect(await jarvis.addScriptMode("jarvis", `${__dirname}/invalidPath/test.jarvis`)).toEqual('Could not read file from the specified location!');
   });
 });

--- a/test/resources/executor.jarvis
+++ b/test/resources/executor.jarvis
@@ -1,0 +1,21 @@
+# define constant
+in this context
+    GREETING is "Bye"
+end
+
+# define macro
+how to greet
+    run hello
+    run world
+end
+
+how to depart
+    load JavaScript
+    say $GREETING
+end
+
+# execute macros
+start farewell
+    greet
+    depart
+end

--- a/test/resources/executors.jarvis
+++ b/test/resources/executors.jarvis
@@ -1,0 +1,25 @@
+# sample constant
+in this context
+    GREETING is "Bye"
+end
+
+# sample macro
+how to greet
+    run hello
+    run world
+end
+
+how to depart
+    load JavaScript
+    say $GREETING
+end
+
+# first execution block
+start welcome
+    greet
+end
+
+# second execution block
+start farewell
+    depart
+end

--- a/test/resources/test.jarvis
+++ b/test/resources/test.jarvis
@@ -1,5 +1,7 @@
-run hello
-run world
-# single line comment
-load JavaScript
-say Bye
+start
+    run hello
+    run world
+    # single line comment
+    load JavaScript
+    say Bye
+end

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -111,6 +111,6 @@ describe('macros', () => {
 describe("scripts", () => {
   test("single line comments", () => {
     expect(parseScript(`${__dirname}/resources/test.jarvis`))
-      .toEqual(["run hello", "run world", "load JavaScript", "say Bye"]);
+      .toEqual(["start", "run hello", "run world", "load JavaScript", "say Bye", "end"]);
   });
 }); 


### PR DESCRIPTION
Changes from this PR makes it mandatory to add execution blocks in order to execute commands and macros in script mode.

examples

 ```
(1) single execution block

# define macro
how to greet
    run hello
    run world
end

# execute macro
start welcome
    greet
end
```
```
(2) Multiple execution blocks

# define macros
how to greet
    run hello
    run world
end

how to depart
    load JavaScript
    say Bye
end

# first execution block
start welcome
    greet
end

# second execution block
start farewell
    depart
end 
```
