### PR TITLE
Added event emitter to access the command responses in run time

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,6 +257,13 @@ class Jarvis {
   }
 
   /**
+   * Wrapper for the event emitter
+   */
+  on(event, callback) {
+    this.eventEmitter.on(event, callback);
+  }
+
+  /**
    * if the 'line' is not found in commands
    * it will search in macros
    */

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const URL = require('url');
+const events = require('events');
 const {
   parseCommand,
   tokenize,
@@ -23,6 +24,7 @@ class Jarvis {
     this.importStack = [__filename]; // use at the time of interpretation to keep track of the import hierarchy in files, default value as current file which used in CLI mode
     this.baseScriptPath = __filename; // the path of the file with which jarvis was invoked. used for resolving import paths, default value as current file which used in CLI mode
     this.importScriptDetails = {}; // contains the imported constants and macros based on the imported script path, USAGE: {'./test.jarvis': ['BASE_URL']}
+    this.eventEmitter = new events.EventEmitter(); // use at the time of script interpretation to emit the responses in run time
   }
 
   /**
@@ -326,7 +328,15 @@ class Jarvis {
         }
       }
       if (this._isInExecutableContext(command)) {
-        res.push(await this.send(command));
+        const response = await this.send(command);
+        /**
+         * Emits the response along with the corresponding command
+         * so the listener can get the response via `command` event in run time
+         */
+        if (this.isInStartBlock) {
+          this.eventEmitter.emit('command', { command, response });
+        }
+        res.push(response);
       }
     }
     return res;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -426,7 +426,7 @@ describe("Event emitter", () => {
 
   test("Command events", async () => {
     const emitObjectArray = [];
-    jarvis.eventEmitter.on('command', (res) => {
+    jarvis.on('command', (res) => {
       emitObjectArray.push(res);
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -392,3 +392,50 @@ describe("import in script mode", () => {
     expect(scriptResponse[scriptResponse.length - 1]).toEqual(['Running, JARVIS']);
   });
 });
+
+describe("Event emitter", () => {
+  const jarvis = new Jarvis();
+
+  jarvis.addCommand({
+    command: "run hello",
+    handler: ({ args }) => {
+      return `Hello`;
+    }
+  });
+
+  jarvis.addCommand({
+    command: "run world",
+    handler: ({ args }) => {
+      return `world`;
+    }
+  });
+
+  jarvis.addCommand({
+    command: "load $language",
+    handler: ({ args }) => {
+      return `Running, ${args.language}`;
+    }
+  });
+
+  jarvis.addCommand({
+    command: "say $string",
+    handler: ({ args }) => {
+      return `${args.string}`;
+    }
+  });
+
+  test("Command events", async () => {
+    const emitObjectArray = [];
+    jarvis.eventEmitter.on('command', (res) => {
+      emitObjectArray.push(res);
+    });
+
+    await jarvis.addScriptMode("jarvis", `./test/resources/test.jarvis`);
+    expect(emitObjectArray).toEqual([
+      { "command": "    run hello", "response": "Hello" },
+      { "command": "    run world", "response": "world" },
+      { "command": "    load JavaScript", "response": "Running, JavaScript" },
+      { "command": "    say Bye", "response": "Bye" }
+    ])
+  });
+});


### PR DESCRIPTION
Add functionality to access (from JavaScript) the response of each command in `start/end` block in run time.

```
// Script
open www.google.com

// JavaScript
...
const jarvis = new Jarvis();
jarvis.addCommand({ command: "open $url", handler: ({ args }) => return 'open successful'});

jarvis.on('command', ({command, response}) => {
   console.log(command)     // open www.google.com
   console.log(response)    // open successful
})
...
```