### PR TITLE
Added JSON import functionality

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -95,23 +95,6 @@ const parseMacroSubCommand = (line, args) => {
 };
 exports.parseMacroSubCommand = parseMacroSubCommand;
 
-// change constant tokens to corresponding values
-// returns same string if no constant found
-const parseConstants = (line, constants) => {
-  let constantTokens = line.match(/\$[A-Z_][0-9A-Z_]*/g);
-  let parsedLine = line;
-  if (constantTokens) {
-    constantTokens.forEach((token) => {
-      let key = token.replace('$', '');
-      if (constants[key]) {
-        parsedLine = parsedLine.replace(token, `"${constants[key]}"`);
-      }
-    })
-  }
-  return parsedLine;
-}
-exports.parseConstants = parseConstants;
-
 // returns string content by reading a script
 const parseScript = filename => {
   let content;
@@ -135,3 +118,18 @@ const validateScript = (extension, file) => {
   }
 };
 exports.validateScript = validateScript;
+
+// read and parse the JSON file
+const importJson = (filename) => {
+  try {
+    const content = fs.readFileSync(filename, "utf8");
+    return JSON.parse(content);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new Error('Could not read the JSON file from the specified location!');
+    } else {
+      throw new Error('Invalid JSON import!');
+    }
+  }
+}
+exports.importJson = importJson;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -251,6 +251,15 @@ describe("constants", () => {
     expect(await jarvis.send('say $NAME')).toEqual('JARVIS');
   });
 
+  test("more than one constant in one argument", async () => {
+    expect(await jarvis.send('say "$NAME is an interpreter"')).toEqual('JARVIS is an interpreter');
+    expect(await jarvis.send('say "Name: $NAME, Version: $VERSION"')).toEqual('Name: JARVIS, Version: 1');
+  });
+
+  test("more than one constant in one argument: some constants are not defined", async () => {
+    expect(await jarvis.send('say "Name: $NAME, Mode: $MODE"')).toEqual('Name: JARVIS, Mode: $MODE');
+  });
+
   test("required constant is not defined", async () => {
     expect(await jarvis.send('say $TYPE')).toEqual('$TYPE')
   });
@@ -437,5 +446,38 @@ describe("Event emitter", () => {
       { "command": "    load JavaScript", "response": "Running, JavaScript" },
       { "command": "    say Bye", "response": "Bye" }
     ])
+  });
+});
+
+describe("JSON imports", () => {
+  const jarvis = new Jarvis();
+
+  jarvis.addCommand({
+    command: "run $argument",
+    handler: ({ args: { argument } }) => {
+      return argument;
+    }
+  });
+
+  test("script with a JSON import", async () => {
+    const scriptResponse = await jarvis.addScriptMode("jarvis", `${__dirname}/resources/json-import.jarvis`);
+    expect(scriptResponse[scriptResponse.length - 1])
+      .toEqual(['Hello', { name: 'JARVIS Interpreter', version: 'version 1.0.0' }, 'JSON Object: {"name":"JARVIS Interpreter","version":"version 1.0.0"}']);
+  });
+
+  test("script with a invalid JSON import", async () => {
+    try {
+      await jarvis.addScriptMode("jarvis", `${__dirname}/resources/invalid-json-import.jarvis`);
+    } catch (error) {
+      expect(error.message).toEqual('Invalid JSON import!');
+    }
+  });
+
+  test("script with a invalid JSON file path ", async () => {
+    try {
+      await jarvis.addScriptMode("jarvis", `${__dirname}/resources/invalid-json-path-import.jarvis`);
+    } catch (error) {
+      expect(error.message).toEqual('Could not read the JSON file from the specified location!');
+    }
   });
 });

--- a/test/resources/invalid-json-import.jarvis
+++ b/test/resources/invalid-json-import.jarvis
@@ -1,0 +1,5 @@
+# define constant
+in this context
+    GREETING_STRING is "Hello"
+    JARVIS_JSON is from "./json/sample-invalid.json"
+end

--- a/test/resources/invalid-json-path-import.jarvis
+++ b/test/resources/invalid-json-path-import.jarvis
@@ -1,0 +1,5 @@
+# define constant
+in this context
+    GREETING_STRING is "Hello"
+    JARVIS_JSON is from "./json/invalid-path/sample-invalid.json"
+end

--- a/test/resources/json-import.jarvis
+++ b/test/resources/json-import.jarvis
@@ -1,0 +1,15 @@
+# define constant
+in this context
+    GREETING_STRING is "Hello"
+    JARVIS_JSON is from "./json/sample.json"
+end
+
+how to log $greeting
+    run $GREETING_STRING
+    run $greeting
+    run "JSON Object: $JARVIS_JSON"
+end
+
+start json test
+    log $JARVIS_JSON
+end

--- a/test/resources/json/sample-invalid.json
+++ b/test/resources/json/sample-invalid.json
@@ -1,0 +1,4 @@
+{
+    "name": JARVIS Interpreter,
+    "version": "version 1.0.0"
+}

--- a/test/resources/json/sample.json
+++ b/test/resources/json/sample.json
@@ -1,0 +1,4 @@
+{
+    "name": "JARVIS Interpreter",
+    "version": "version 1.0.0"
+}


### PR DESCRIPTION
### Feature to import JSON objects as constants

```
in this context
   JARVIS_JSON is from "./json/sample.json"
end
```

##### Change log:
- Update `parseConstants` function to parse the object constants.

- Function `parseConstants` is moved to `index.js` from `utils.js` since it allows `parseConstant` to directly access constant object without passing it to utils. 
 
- Redundant `parseConstants` function calls were removed from `_findMacro` and `_runMacro` since the every command (macro sub command and command) is going through `_runCommand` method at the end.