### PR TITLE
Feature to import constants from environment file

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ const tokenize = line => {
 };
 exports.tokenize = tokenize;
 
-// converts 'hello $name' to 
+// converts 'hello $name' to
 // [{value: 'hello', isArg: false}, {value: name, isArg: true}]
 const parseCommand = (commandStr) => {
   const tokens = [];
@@ -105,7 +105,7 @@ const parseScript = filename => {
   }
   const lines = content.split("\n");
   const filteredCommands = lines.filter(line => {
-    return line !== "" && !line.trim().startsWith("#");
+    return line !== "" && line.trim() !== "" && !line.trim().startsWith("#");
   });
   return filteredCommands;
 };
@@ -118,6 +118,12 @@ const validateScript = (extension, file) => {
   }
 };
 exports.validateScript = validateScript;
+
+//checks whether a given env file/file path matches to a given file name
+const validateEnvFileName = (fileName, envFile) => {
+  return envFile.split('.').pop() === fileName;
+};
+exports.validateEnvFileName = validateEnvFileName;
 
 // read and parse the JSON file
 const importJson = (filename) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -402,6 +402,46 @@ describe("import in script mode", () => {
   });
 });
 
+describe("Import from environment file", () => {
+  const jarvis = new Jarvis();
+
+  jarvis.addCommand({
+    command: "run hello",
+    handler: () => {
+      return `Hello`;
+    }
+  });
+
+  jarvis.addCommand({
+    command: "load $language",
+    handler: ({ args }) => {
+      return `Running, ${args.language}`;
+    }
+  });
+
+  jarvis.addCommand({
+    command: "say $string",
+    handler: ({ args }) => {
+      return `${args.string}`;
+    }
+  });
+
+  test("Import constants from env", async () => {
+    const scriptResponse = await jarvis.addScriptMode("jarvis", `./test/resources/import-env.jarvis`, `./test/resources/.jarvisrc`);
+    expect(scriptResponse[scriptResponse.length - 1]).toEqual(['Hello', 'Running, JARVIS']);
+  });
+
+  test("Import env with invalid syntax", async () => {
+    const scriptResponse = await jarvis.addScriptMode("invalid", `./test/resources/import-env.invalid`, `./test/resources/.invalidrc`);
+    expect(scriptResponse).toEqual('Invalid syntax in env file!');
+  });
+
+  test("Import env with invalid file path", async () => {
+    const scriptResponse = await jarvis.addScriptMode("jarvis", `./test/resources/import-env.jarvis`, `./test/invalidDir/.jarvisrc`)
+    expect(scriptResponse).toEqual('Could not read env file from specified location!');
+  });
+});
+
 describe("Event emitter", () => {
   const jarvis = new Jarvis();
 

--- a/test/resources/.invalidrc
+++ b/test/resources/.invalidrc
@@ -1,0 +1,1 @@
+INVALID is "NOT_JARVIS"

--- a/test/resources/.jarvisrc
+++ b/test/resources/.jarvisrc
@@ -1,0 +1,3 @@
+in this context
+    PROGRAM is "JARVIS"
+end

--- a/test/resources/import-env.invalid
+++ b/test/resources/import-env.invalid
@@ -1,0 +1,13 @@
+in this context
+    INVALID is from env
+end
+
+how to play
+    run hello
+    load $INVALID
+end
+
+start test
+    play
+end
+

--- a/test/resources/import-env.jarvis
+++ b/test/resources/import-env.jarvis
@@ -1,0 +1,14 @@
+in this context
+    PROGRAM is from env
+    NOT_DEFINED is from env
+end
+
+how to work
+    run hello
+    load $PROGRAM
+end
+
+start test
+    work
+end
+


### PR DESCRIPTION
Changes from this PR allows users to import constants from an environment file.
- Sample environment file is as follows ( `.jarvisrc`)

```
# sample env file

in this context
    PROGRAM is "JARVIS"
end
```
- Sample import from environment file
```
in this context
    PROGRAM is from env
end

how to work
    run hello
    load $PROGRAM
end

start test
    work
end
```
- Environment file can be passed as an optional parameter

  ex:- Sample test case

```

 describe("Import from environment file", () => {
  const jarvis = new Jarvis();

  jarvis.addCommand({
    command: "run hello",
    handler: () => {
      return `Hello`;
    }
  });

  jarvis.addCommand({
    command: "load $language",
    handler: ({ args }) => {
      return `Running, ${args.language}`;
    }
  });

  jarvis.addCommand({
    command: "say $string",
    handler: ({ args }) => {
      return `${args.string}`;
    }
  });

  test("Import constants from env", async () => {
    const scriptResponse = await jarvis.addScriptMode("jarvis", `./test/resources/import-env.jarvis`, `./test/resources/.jarvisrc`);
    expect(scriptResponse[scriptResponse.length - 1]).toEqual(['Hello', 'Running, JARVIS']);
  });
```
