### PR TITLE
Added options to define help for commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ class Jarvis {
    * Registers a new command with Jarvis
    * USAGE: jarvis.addCommand({ command: 'test', handler: () => {}});
    */
-  addCommand({ command, handler, aliases }) {
+  addCommand({ command, handler, aliases, help }) {
     const patterns = [];
     patterns.push({ tokens: parseCommand(command) });
     if (aliases) {
@@ -66,6 +66,7 @@ class Jarvis {
     this.commands.push({
       command: command,
       handler: handler,
+      help: help,
       tokens: parseCommand(command),
       patterns
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -135,6 +135,21 @@ describe("aliases", () => {
   });
 });
 
+describe("command help", () => {
+  const jarvis = new Jarvis();
+  jarvis.addCommand({
+    command: "greet $name",
+    help: "greet 'John' - Greets a specified person",
+    handler: ({ args }) => {
+      return `Hello ${args.name}`;
+    }
+  });
+
+  test("should ", async () => {
+    expect(jarvis.commands[0].help).toEqual("greet 'John' - Greets a specified person");
+  });
+});
+
 describe('macros', () => {
   const jarvis = new Jarvis();
 


### PR DESCRIPTION
Changes from this PR provide users the option to add a `help` string to a command.
ex:-
```  
app.addCommand({
    command: "greet $name",
    help: "greet 'John' - Greets a specified person",
    handler: ({ args }) => {
      return `Hello ${args.name}`;
    }
  });
```